### PR TITLE
Add Snyk DevSecOps Hub

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
   - [Secure Development Lifecycle Framework](#secure-development-lifecycle-framework)
   - [Toolchains](#toolchains)
   - [Training](#training)
+  - [Wikis](#wikis)
 - [Tools](#tools)
   - [Dependency Management](#dependency-management)
   - [Dynamic Analysis](#dynamic-analysis)
@@ -84,6 +85,10 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Security Training for Engineers](https://sudo.pagerduty.com/for_engineers/) - _Pager Duty_ - A presentation created and open-sourced by PagerDuty to provide security training to software engineers.
 - [Security Training for Everyone](https://sudo.pagerduty.com/for_everyone/) - _Pager Duty_ - A presentation created and open-sourced by PagerDuty to provide security training employees.
 - [Web Security Academy](https://portswigger.net/web-security) - _PortSwigger_ - A set of materials and labs to learn and exploit common web vulnerabilities.
+
+### Wikis
+
+- [DevSecOps Hub](https://snyk.io/devsecops/) - _Snyk_ - Introduction to key DevSecOps concepts, processes and technologies.
 
 ## Tools
 


### PR DESCRIPTION
Snyk's DevSecOps Hub is a great resource for people new to DevSecOps who want to understand DSO at a high-level.