### PR TITLE
Replaced broken link to Secure DevOps Toolchain poster with Cloud Sec…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,8 +83,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 ### Toolchains
 
+- [Cloud Security and DevSecOps Best Practices _and_ Securing Web Application Technologies (SWAT) Checklist](https://www.sans.org/posters/cloud-security-devsecops-best-practices/) - _SANS_ - A poster containing the Securing Web Application Technologies (SWAT) Checklist, SANS Cloud Security Curriculum, Cloud Security Top 10, Top 12 Kubernetes Threats, and Secure DevOps Toolchain.
 - [Periodic Table of DevOps Tools](https://xebialabs.com/periodic-table-of-devops-tools/) - _XebiaLabs_ - A collection of DevSecOps tooling categorised by tool functionality.
-- [Secure DevOps Toolchain](https://www.sans.org/security-resources/posters/secure-devops-toolchain-swat-checklist/60/download) - _SANS_ - A list of security specific practices and tooling categorised into pipeline phases and tool functionality.
 
 ### Training
 


### PR DESCRIPTION
…urity and DevSecOps Best Practices poster

The SANS Secure DevOps Toolchain poster link is broken. The poster itself seems to have disappeared from the internet. (Plus it's probably a bit dated.)

In its place I have added a current (April 2021) link to a different but similar poster.