### PR TITLE
Add harden-runner to supply chain security section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -303,7 +303,10 @@ Supply chain attacks come in different forms, targeting parts of the SDLC that a
 
 - [Preflight](https://github.com/spectralops/preflight) - _Spectral_ - helps you verify scripts and executables to mitigate supply chain attacks in your CI and other systems, such as in the recent [Codecov hack](https://spectralops.io/blog/credentials-risk-supply-chain-lessons-from-the-codecov-breach/).
 - [Sigstore](https://www.sigstore.dev/) - sigstore is a set of free to use and open source tools, including [fulcio](https://github.com/sigstore/fulcio), [cosign](https://github.com/sigstore/cosign) and [rekor](https://github.com/sigstore/rekor), handling digital signing, verification and checks for provenance needed to make it safer to distribute and use open source software.
-
+- [Harden Runner GitHub Action](https://github.com/step-security/harden-runner) - Harden-Runner GitHub Action installs a security agent on the GitHub-hosted runner (Ubuntu VM) to:
+  1. Prevent exfiltration of credentials
+  2. Detect compromised dependencies and build tools
+  3. Detect tampering of source code during the build
 
 ### Threat Modelling
 

--- a/readme.md
+++ b/readme.md
@@ -301,12 +301,9 @@ Static Analysis Security Testing (SAST) tools scan software for vulnerabilities 
 
 Supply chain attacks come in different forms, targeting parts of the SDLC that are inherently 3rd party: tools in CI, external code that's been executed, and more. Supply chain security tooling can defend against these kinds of attacks.
 
+- [Harden Runner GitHub Action](https://github.com/step-security/harden-runner) - _StepSecurity_ - installs a security agent on the GitHub-hosted runner (Ubuntu VM) to prevent exfiltration of credentials, detect compromised dependencies and build tools, and detect tampering of source code during the build.
 - [Preflight](https://github.com/spectralops/preflight) - _Spectral_ - helps you verify scripts and executables to mitigate supply chain attacks in your CI and other systems, such as in the recent [Codecov hack](https://spectralops.io/blog/credentials-risk-supply-chain-lessons-from-the-codecov-breach/).
 - [Sigstore](https://www.sigstore.dev/) - sigstore is a set of free to use and open source tools, including [fulcio](https://github.com/sigstore/fulcio), [cosign](https://github.com/sigstore/cosign) and [rekor](https://github.com/sigstore/rekor), handling digital signing, verification and checks for provenance needed to make it safer to distribute and use open source software.
-- [Harden Runner GitHub Action](https://github.com/step-security/harden-runner) - Harden-Runner GitHub Action installs a security agent on the GitHub-hosted runner (Ubuntu VM) to:
-  1. Prevent exfiltration of credentials
-  2. Detect compromised dependencies and build tools
-  3. Detect tampering of source code during the build
 
 ### Threat Modelling
 


### PR DESCRIPTION
This PR adds information about https://github.com/step-security/harden-runner GitHub Action to supply chain security section. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>