### PR TITLE
Add Meta Package Manager.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Application Security Education](https://github.com/duo-labs/appsec-education) - _Duo Security_ - Training materials created by the Duo application security team, including introductory and advanced training presentations and hands-on labs.
 - [Cybrary](https://www.cybrary.it/) - _Cybrary_ - Subscription based online courses with dedicated categories for cybersecurity and DevSecOps.
+- [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) - _Kevin Deldycke_ - Open-source CLI to inventory all packages installed on macOS, Linux and Windows.
 - [PentesterLab](https://pentesterlab.com/) - _PentesterLab_ - Hands on labs to understand and exploit simple and advanced web vulnerabilities.
 - [Practical DevSecOps](https://www.practical-devsecops.com) - _Practical DevSecOps_ - Learn DevSecOps concepts, tools, and techniques from industry experts with practical DevSecOps using state of the art browser-based labs.
 - [SafeStack](https://academy.safestack.io/) - _SafeStack_ - Security training for software development teams, designed to be accessible to individuals and small teams as well as larger organisations.


### PR DESCRIPTION
Meta Package Manager provides the `mpm` CLI, a wrapper around all package managers.

Features:

- Inventory and list all package managers available on the system.
- Supports macOS, Linux and Windows.
- List installed packages.
- Search for packages.
- Install a package.
- Remove a package.
- List outdated packages.
- Sync local package infos.
- Upgrade all outdated packages.
- Backup list of installed packages to TOML file.
- Restore/install list of packages from TOML files.
- Pin-point commands to a subset of package managers (include/exclude selectors).
- Support plain, versionned and [purl](https://github.com/package-url/purl-spec) package specifiers.
- Export output to JSON or print user-friendly tables.
- Shell auto-completion for Bash, Zsh and Fish.
