### PR TITLE
Add Kubescape

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,7 @@ Infrastructure as Code allows applications to be deployed reliably to a consiste
 
 <!-- omit in toc -->
 #### Kubernetes
+- [Kubescape](https://kubescape.io/) - _Cloud Native Computing Foundation_ - An open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters.
 - [Kube-Score](https://github.com/zegl/kube-score) - _Gustav Westling_ - Scan Kubernetes object definitions for security and performance misconfiguration.
 - [Kubectrl Kubesec](https://github.com/controlplaneio/kubectl-kubesec) - _ControlPlane_ - Plugin for kubesec.io to perform security risk analysis for Kubernetes resources.
 


### PR DESCRIPTION
add Kubescape to the Kubernetes security tool list.

Kubescape is a CNCF project to manage the security posture of Kubernetes clusters, including tooling to look at workloads before they are deployed.