### PR TITLE
Add dotsecrets to Secrets Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -218,6 +218,7 @@ The software we write needs to use secrets (passwords, API keys, certificates, d
 - [CredStash](https://github.com/fugue/credstash) - _Fugue_ - Securely store secrets within AWS using KMS and DynamoDB.
 - [CyberArk Application Access Manager](https://www.cyberark.com/products/privileged-account-security-solution/application-access-manager/) - _CyberArk_ - Secrets management for applications including secret rotation and auditing.
 - [Docker Secrets](https://docs.docker.com/engine/swarm/secrets/) - _Docker_ - Store and manage access to secrets within a Docker swarm.
+- [dotsecrets](https://github.com/kamilchm/dotsecrets) - Simple and easy secrets in git, perfect for small teams.
 - [Git Secrets](https://github.com/awslabs/git-secrets) - _Amazon AWS_ - Scan git repositories for secrets committed within code or commit messages.
 - [Gopass](https://github.com/gopasspw/gopass) - _Gopass_ - Password manager for teams relying on Git and gpg. Manages secrets in encrypted files and repositories.
 - [Google Cloud Key Management Service (KMS)](https://cloud.google.com/kms) - _Google Cloud Platform_ - Securely store secrets within GCP.


### PR DESCRIPTION
dotsecrets is a small self-contained bash script for encrypting secrets in a git repo.