### PR TITLE
Add Meta Package Manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,6 +323,7 @@ Supply chain attacks come in different forms, targeting parts of the SDLC that a
 - [Preflight](https://github.com/spectralops/preflight) - _Spectral_ - helps you verify scripts and executables to mitigate supply chain attacks in your CI and other systems, such as in the recent [Codecov hack](https://spectralops.io/blog/credentials-risk-supply-chain-lessons-from-the-codecov-breach/).
 - [Sigstore](https://www.sigstore.dev/) - sigstore is a set of free to use and open source tools, including [fulcio](https://github.com/sigstore/fulcio), [cosign](https://github.com/sigstore/cosign) and [rekor](https://github.com/sigstore/rekor), handling digital signing, verification and checks for provenance needed to make it safer to distribute and use open source software.
 - [Syft](https://github.com/anchore/syft/) - _Anchore_ - A CLI tool for generating a Software Bill of Materials (SBOM) from container images and filesystems.
+- [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) - _Kevin Deldycke_ - An all-in-one CLI to export a Software Bill of Materials (SBOM) of all packages installed on macOS, Linux and Windows, in SPDX or CycloneDX format.
 
 ### Threat Modelling
 


### PR DESCRIPTION
A follow-up on #68: now that Meta Package Manager can [export a SBOM of all packages installed](https://kdeldycke.github.io/meta-package-manager/usecase.html#sbom-software-bill-of-materials) on macOS, Linux or Windows, it perfectly complement the `Syft` project referenced above.