### PR TITLE
Add ReleaseRun vulnerability scanner to Dependency Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ Open source software packages can speed up the development process by allowing d
 - [Renovate](https://renovate.whitesourcesoftware.com/) - _WhiteSource_ - Automatically monitor and update software dependencies for multiple frameworks and languages using a CLI or git repository apps.
 - [Requires.io](https://requires.io/) - _Olivier Mansion & Alexis Tabary_ - Automated vulnerable dependency monitoring and upgrades for Python projects.
 - [Snyk Open Source](https://snyk.io/product/open-source-security-management/) - _Snyk_ - Automated vulnerable dependency monitoring and upgrades using Snyk's dedicated vulnerability database.
+- [ReleaseRun](https://releaserun.com/badges/) - _ReleaseRun_ - Embeddable badges showing CVE counts, EOL status, and version health for 300+ software products.
 
 ### Dynamic Analysis
 


### PR DESCRIPTION
ReleaseRun is a free dependency vulnerability scanner that checks CVE exposure and end-of-life status across 300+ software products.

Fits alongside Dependency-Check, Snyk, and Renovate in the Dependency Management section. Checks both known vulnerabilities and EOL/unsupported versions.

Available as a web tool and npm CLI (`npx releaserun`) for CI/CD integration.

Website: https://releaserun.com
Tool: https://releaserun.com/tools/vulnerability-scanner/
CLI: https://www.npmjs.com/package/releaserun