### PR TITLE
Add ReleaseRun to monitoring and release tracking tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ Open source software packages can speed up the development process by allowing d
 - [Renovate](https://renovate.whitesourcesoftware.com/) - _WhiteSource_ - Automatically monitor and update software dependencies for multiple frameworks and languages using a CLI or git repository apps.
 - [Requires.io](https://requires.io/) - _Olivier Mansion & Alexis Tabary_ - Automated vulnerable dependency monitoring and upgrades for Python projects.
 - [Snyk Open Source](https://snyk.io/product/open-source-security-management/) - _Snyk_ - Automated vulnerable dependency monitoring and upgrades using Snyk's dedicated vulnerability database.
+- [ReleaseRun](https://releaserun.com/badges/) - _ReleaseRun_ - Embeddable badges showing CVE counts, EOL status, and version health for 300+ software products.
 
 ### Dynamic Analysis
 


### PR DESCRIPTION
**ReleaseRun** (https://releaserun.com) is a free platform for software release monitoring and dependency health tracking.

It provides browser-based tools for:
- Kubernetes API deprecation checking before cluster upgrades
- Dependency EOL scanning (npm, pip, cargo, gem, composer, go.mod)
- CVE dashboard and release monitoring across 13+ technologies
- Helm chart compatibility checking

Used by DevOps and SRE teams to stay ahead of breaking changes in their stack.