### PR TITLE
Add Git AutoReview to Static Analysis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,7 @@ Static Analysis Security Testing (SAST) tools scan software for vulnerabilities 
 #### Multi-Language Support
 
 - [DevSkim](https://github.com/microsoft/DevSkim) - _Microsoft_ - A set of IDE plugins, CLIs and other tools that provide security analysis for a number of programming languages.
+- [Git AutoReview](https://gitautoreview.com) - _Git AutoReview_ - VS Code extension that reviews GitHub, GitLab and Bitbucket pull requests with AI, ships 20+ built-in security rules and keeps a human approval step before any comment is posted.
 - [Graudit](https://github.com/wireghoul/graudit/) - _Eldar Marcussen_ - Grep source code for potential security flaws with custom or pre-configured regex signatures.
 - [Hawkeye](https://github.com/hawkeyesec/scanner-cli) - _Hawkeyesec_ - Modularised CLI tool for project security, vulnerability and general risk highlighting.
 - [LGTM](https://lgtm.com/) - _Semmle_ - Scan and monitor code for security vulnerabilities using custom or built-in CodeQL queries.


### PR DESCRIPTION
Adds Git AutoReview to Static Analysis → Multi-Language Support (alphabetical, between DevSkim and Graudit).

Git AutoReview is a VS Code extension for AI-assisted code review with a human approval step — every AI suggestion is a draft the developer accepts or rejects before it reaches the pull request. It ships 20+ built-in security rules (SQL injection, XSS, hardcoded secrets, insecure crypto, path traversal) plus an AI pass for logic-level issues like auth bypasses. BYOK keeps code private: it goes straight from the editor to Anthropic, Google or OpenAI, nothing is stored server-side. Works with GitHub, GitLab (Cloud and Self-Managed) and Bitbucket (Cloud, Server and Data Center).

Per contributing.md: single suggestion, alphabetised, `[Resource](link) - _Maintainer_` format, and readme.md is the only file touched — my earlier #106 accidentally dragged in unrelated files from a stale fork, so I closed it; this one supersedes it.
